### PR TITLE
Add server mode

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+jobs
+venv
+upgrade-helm.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 jobs
 __pycache__
+build/
+dist/
+goji.egg-info/
+venv/
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+RUN python3 setup.py sdist bdist_wheel
+RUN pip install dist/*.whl
+
+RUN git config --global user.email "goji-bot@goji"
+RUN git config --global user.name "Goji Bot"
+
+CMD [ "goji", "server" ]
+

--- a/askpass.py
+++ b/askpass.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+from sys import argv
+from os import environ
+
+if 'username' in argv[1].lower():
+    print(environ['GIT_USERNAME'])
+    exit()
+
+if 'password' in argv[1].lower():
+    print(environ['GIT_PASSWORD'])
+    exit()
+
+exit(1)

--- a/charts/goji/.helmignore
+++ b/charts/goji/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/goji/Chart.yaml
+++ b/charts/goji/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: goji
+version: 0.1.0

--- a/charts/goji/templates/NOTES.txt
+++ b/charts/goji/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "goji.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "goji.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "goji.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "goji.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/charts/goji/templates/_helpers.tpl
+++ b/charts/goji/templates/_helpers.tpl
@@ -1,0 +1,56 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "goji.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "goji.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "goji.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "goji.labels" -}}
+app.kubernetes.io/name: {{ include "goji.name" . }}
+helm.sh/chart: {{ include "goji.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "goji.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "goji.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/goji/templates/clusterrole.yaml
+++ b/charts/goji/templates/clusterrole.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.defaultClusterRole -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+ name: goji
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["create", "get", "describe", "list", "watch", "exec"]
+{{- end -}}

--- a/charts/goji/templates/clusterrolebinding.yaml
+++ b/charts/goji/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.defaultClusterRole -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+ name: goji
+roleRef:
+ kind: ClusterRole
+ name: goji
+ apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: goji
+  namespace: jobs
+{{- end -}}

--- a/charts/goji/templates/deployment.yaml
+++ b/charts/goji/templates/deployment.yaml
@@ -40,6 +40,8 @@ spec:
               value: {{ .Values.githubRepo }}
             - name: GIT_ASKPASS
               value: "/usr/src/app/askpass.py"
+            - name: IN_CLUSTER
+              value: "true"
           ports:
             - name: http
               containerPort: 80

--- a/charts/goji/templates/deployment.yaml
+++ b/charts/goji/templates/deployment.yaml
@@ -40,6 +40,8 @@ spec:
               value: {{ .Values.githubRepo }}
             - name: GIT_ASKPASS
               value: "/usr/src/app/askpass.py"
+            - name: GITHUB_WEBHOOK_SECRET
+              value: {{ .Values.githubWebhookSecret }}
             - name: IN_CLUSTER
               value: "true"
           ports:

--- a/charts/goji/templates/deployment.yaml
+++ b/charts/goji/templates/deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "goji.fullname" . }}
+  labels:
+{{ include "goji.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "goji.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "goji.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ template "goji.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: GIT_USERNAME
+              value: {{ .Values.githubUser }}
+            - name: GIT_PASSWORD
+              value: {{ .Values.githubPat }}
+            - name: GIT_REPOSITORY
+              value: {{ .Values.githubRepo }}
+            - name: GIT_ASKPASS
+              value: "/usr/src/app/askpass.py"
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/goji/templates/deployment.yaml
+++ b/charts/goji/templates/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
 {{ include "goji.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "goji.name" . }}

--- a/charts/goji/templates/ingress.yaml
+++ b/charts/goji/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "goji.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+{{ include "goji.labels" . | indent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/goji/templates/service.yaml
+++ b/charts/goji/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "goji.fullname" . }}
+  labels:
+{{ include "goji.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "goji.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/goji/templates/serviceaccount.yaml
+++ b/charts/goji/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "goji.serviceAccountName" . }}
+  labels:
+{{ include "goji.labels" . | indent 4 }}
+{{- end -}}

--- a/charts/goji/templates/tests/test-connection.yaml
+++ b/charts/goji/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "goji.fullname" . }}-test-connection"
+  labels:
+{{ include "goji.labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args:  ['{{ include "goji.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/goji/values.yaml
+++ b/charts/goji/values.yaml
@@ -1,0 +1,73 @@
+# Default values for goji.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: shteou/goji
+  tag: gaas
+  pullPolicy: Always
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: goji
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+githubUser: ""
+githubPat: ""
+githubRepo: ""
+defaultClusterRole: true

--- a/charts/goji/values.yaml
+++ b/charts/goji/values.yaml
@@ -71,3 +71,4 @@ githubUser: ""
 githubPat: ""
 githubRepo: ""
 defaultClusterRole: true
+githubWebhookSecret: ""

--- a/goji/Runner.py
+++ b/goji/Runner.py
@@ -6,6 +6,7 @@ import sys
 
 from goji.commands.init import command_init
 from goji.commands.process import command_process
+from goji.commands.server import command_server
 from goji.commands.template import command_template
 from goji.jobs import *
 from goji.dir_tools import *
@@ -20,6 +21,7 @@ class Goji(object):
    process    Process gitops jobs
    requeue    Requeues a job which is in a failed or unknown state
    init       Scaffold a new jobs directory
+   server     Run as a server, which processes new jobs via webhooks
 
 ''')
 
@@ -69,6 +71,15 @@ class Goji(object):
 
     command_template(args)
 
+  def server(self):
+    parser = argparse.ArgumentParser(
+               description='''Executes goji as a service
+''')
+
+    parser.add_argument("--repository", help="Specifies the jobs repository")
+    args = parser.parse_args(self.main_args[2:])
+
+    command_server(args.repository)
 
   def init(self):
     parser = argparse.ArgumentParser(

--- a/goji/Runner.py
+++ b/goji/Runner.py
@@ -29,9 +29,9 @@ class Goji(object):
     args = parser.parse_args(self.main_args[1:2])
 
     if not hasattr(self, args.command):
-            print(args.command + ' is not a valid command')
-            parser.print_help()
-            exit(1)
+      print(args.command + ' is not a valid command')
+      parser.print_help()
+      exit(1)
 
     getattr(self, args.command)()
 

--- a/goji/commands/init.py
+++ b/goji/commands/init.py
@@ -1,22 +1,23 @@
 import os
 import git
 
+from goji.logger import log
 from goji.dir_tools import make_empty_git_dir
 from goji.jobs import job_states
 
 def command_init(repository):
     if os.path.exists('jobs'):
-      print("jobs directory already exists... skipping")
+      log.info("jobs directory already exists... skipping")
     elif repository:
       os.makedirs("jobs")
-      print("Cloning " + repository)
+      log.info("Cloning " + repository)
       git.Repo.clone_from(repository, "jobs")
-      print("Done")
+      log.info("Done")
     else:
-      print("Scaffolding a jobs repository")
+      log.info("Scaffolding a jobs repository")
       for d in map(lambda x: os.path.join("jobs", x), job_states()):
         make_empty_git_dir(d)
-      print('''Done, please run:
+      log.info('''Done, please run:
   $ cd jobs
   $ git init
   $ git add .

--- a/goji/commands/process.py
+++ b/goji/commands/process.py
@@ -1,30 +1,31 @@
 import sys
 
+from goji.logger import log
 from goji.jobs import *
 
 # Applies all queued jobs and transitions to processing/failed
 # as required
 def command_process(jobs):
-  print("Checking for duplicate jobs")
+  log.info("Checking for duplicate jobs")
   duplicates = duplicate_jobs()
   if len(duplicates) > 0 :
-    print("Removing duplicate jobs")
+    log.warn("Removing duplicate jobs")
     delete_jobs("queued", duplicates, "Deleting duplicated jobs")
 
   unique_jobs = [j for j in jobs if j not in duplicates]
-  print(f"Processing remaining jobs: {unique_jobs}")
+  log.info(f"Processing remaining jobs: {unique_jobs}")
   for job in unique_jobs:
     try:
-      print(f"Processing {job}")
+      log.info(f"Processing {job}")
       if apply_job(job):
         move_job(job, "queued", "processing")
-        print(f"Processing {job} succeeded")
+        log.info(f"Processing {job} succeeded")
       else:
         move_job(job, "queued", "failed")
-        print(f"Processing {job} failed")
+        log.error(f"Processing {job} failed")
 
     except Exception as e:
-      print(f"Encountered an unexpected exception whilst processing {job}")
-      print(e)
+      log.error(f"Encountered an unexpected exception whilst processing {job}")
+      log.error(e)
 
-  print("Finished processing jobs")
+  log.info("Finished processing jobs")

--- a/goji/commands/process.py
+++ b/goji/commands/process.py
@@ -7,13 +7,13 @@ from goji.jobs import *
 def command_process(jobs):
   print("Checking for duplicate jobs")
   duplicates = duplicate_jobs()
-  if bool(duplicates):
-    print("Error, found the following duplicate jobs: ", duplicates)
-    sys.exit(1)
-  print("No duplicates found")
+  if len(duplicates) > 0 :
+    print("Removing duplicate jobs")
+    delete_jobs("queued", duplicates, "Deleting duplicated jobs")
 
-  print(f"Processing jobs: {jobs}")
-  for job in jobs:
+  unique_jobs = [j for j in jobs if j not in duplicates]
+  print(f"Processing remaining jobs: {unique_jobs}")
+  for job in unique_jobs:
     try:
       print(f"Processing {job}")
       if apply_job(job):

--- a/goji/commands/server.py
+++ b/goji/commands/server.py
@@ -4,7 +4,7 @@ import goji.server
 from goji.logger import log
 
 def server(args):
-  http_server = WSGIServer(('', 8080), goji.server.app)
+  http_server = WSGIServer(('', 8080), goji.server.app, log=log)
   http_server.serve_forever()
   logging.setLogger(log)
 

--- a/goji/commands/server.py
+++ b/goji/commands/server.py
@@ -1,0 +1,11 @@
+import os
+from gevent.pywsgi import WSGIServer
+import goji.server
+
+def server(args):
+  http_server = WSGIServer(('', 8080), goji.server.app)
+  http_server.serve_forever()
+
+def command_server(args):
+  server(args)
+

--- a/goji/commands/server.py
+++ b/goji/commands/server.py
@@ -1,10 +1,12 @@
 import os
 from gevent.pywsgi import WSGIServer
 import goji.server
+from goji.logger import log
 
 def server(args):
   http_server = WSGIServer(('', 8080), goji.server.app)
   http_server.serve_forever()
+  logging.setLogger(log)
 
 def command_server(args):
   server(args)

--- a/goji/commands/template.py
+++ b/goji/commands/template.py
@@ -1,6 +1,8 @@
 import os
 import sys
 
+from goji.logger import log
+
 def templates(args):
     return {
         "basic-job": f'''
@@ -31,9 +33,9 @@ def command_template(args):
         new_job = template_file.read().format(args=args)
         with open(os.path.join("jobs", "queued", args.filename), "w+") as job_file:
           job_file.write(new_job)
-    print("Template created")
+    log.info("Template created")
 
   except Exception as e:
-    print("Template creation failed")
-    print(e)
-    print(e.args)
+    log.error("Template creation failed")
+    log.error(e)
+    log.error(e.args)

--- a/goji/jobs.py
+++ b/goji/jobs.py
@@ -1,3 +1,4 @@
+
 import functools
 import git
 import os
@@ -13,7 +14,7 @@ def job_states():
 def apply_job(job_name):
   try:
     print("Applying job {job_name}")
-    if os.environ["IN_CLUSTER"] == "true":
+    if "IN_CLUSTER" in os.environ and os.environ["IN_CLUSTER"] == "true":
       k8s_config = config.load_incluster_config()
     else:
       k8s_config = config.load_kube_config()
@@ -48,6 +49,15 @@ def list_job_files(state):
 # Is a file a valid job file, i.e. has a yaml extension
 def is_job_file(file):
   return file.endswith(".yaml")
+
+def delete_job(state, job, message):
+  delete_jobs(state, [job], message)
+
+def delete_jobs(state, jobs, message):
+  repo = git.Repo("jobs")
+  job_paths = [os.path.join(state, j) for j in jobs]
+  repo.index.remove(items=job_paths)
+  repo.git.commit(message=message)
 
 # Checks for any duplicate jobs
 # A job is considered a duplicate if it is present in the queued

--- a/goji/jobs.py
+++ b/goji/jobs.py
@@ -31,8 +31,8 @@ def apply_job(job_name):
 # Move a job from one state to another, creating a commit and pushing the result
 def move_job(filename, source_state, destination_state):
   log.info(f"Moving {filename} from {source_state} to {destination_state}")
+  repo = git.Repo("jobs")
   try:
-    repo = git.Repo("jobs")
     repo.index.move([os.path.join(source_state, filename), os.path.join(destination_state, filename)])
     log.info(f"Committing state transition for {filename}")
     commit = repo.index.commit(f"{filename} transitioned from {source_state} to {destination_state}")
@@ -43,6 +43,8 @@ def move_job(filename, source_state, destination_state):
   except Exception as e:
     log.error(f"Failed to move {filename}")
     log.error(e)
+    # Pull the latest. In case of remote changes, next operation should re-push changes
+    repo.remotes.origin.pull()
 
 # Lists all jobs (i.e. yaml files) within a given state
 def list_job_files(state):

--- a/goji/jobs.py
+++ b/goji/jobs.py
@@ -3,6 +3,8 @@ import functools
 import git
 import os
 
+from goji.logger import log
+
 from kubernetes import client, config
 from kubernetes.utils import create_from_yaml
 
@@ -13,7 +15,7 @@ def job_states():
 # Returns whether or the job was applied successfuly
 def apply_job(job_name):
   try:
-    print("Applying job {job_name}")
+    log.info("Applying job {job_name}")
     if "IN_CLUSTER" in os.environ and os.environ["IN_CLUSTER"] == "true":
       k8s_config = config.load_incluster_config()
     else:
@@ -21,26 +23,26 @@ def apply_job(job_name):
     k8s_client = client.api_client.ApiClient(configuration=k8s_config)
     create_from_yaml(k8s_client, f"jobs/queued/{job_name}")
   except Exception as e:
-    print(f"Failed to apply job {job_name}:")
-    print(e)
+    log.error(f"Failed to apply job {job_name}:")
+    log.error(e)
     return False
   return True
 
 # Move a job from one state to another, creating a commit and pushing the result
 def move_job(filename, source_state, destination_state):
-  print(f"Moving {filename} from {source_state} to {destination_state}")
+  log.info(f"Moving {filename} from {source_state} to {destination_state}")
   try:
     repo = git.Repo("jobs")
     repo.index.move([os.path.join(source_state, filename), os.path.join(destination_state, filename)])
-    print(f"Committing state transition for {filename}")
+    log.info(f"Committing state transition for {filename}")
     commit = repo.index.commit(f"{filename} transitioned from {source_state} to {destination_state}")
-    print(f"Pushing commit {commit} for {filename}")
+    log.info(f"Pushing commit {commit} for {filename}")
     origin = repo.remote(name='origin')
     origin.push()
   except Exception as e:
-    print(f"Failed to move {filename}")
-    print(e)
-  print(f"Successfully moved {filename}")
+    log.error(f"Failed to move {filename}")
+    log.error(e)
+  log.info(f"Successfully moved {filename}")
 
 # Lists all jobs (i.e. yaml files) within a given state
 def list_job_files(state):

--- a/goji/jobs.py
+++ b/goji/jobs.py
@@ -13,8 +13,10 @@ def job_states():
 def apply_job(job_name):
   try:
     print("Applying job {job_name}")
-    #k8s_config = config.load_kube_config()
-    k8s_config = config.load_incluster_config()
+    if os.environ["IN_CLUSTER"] == "true":
+      k8s_config = config.load_incluster_config()
+    else:
+      k8s_config = config.load_kube_config()
     k8s_client = client.api_client.ApiClient(configuration=k8s_config)
     create_from_yaml(k8s_client, f"jobs/queued/{job_name}")
   except Exception as e:

--- a/goji/jobs.py
+++ b/goji/jobs.py
@@ -39,10 +39,10 @@ def move_job(filename, source_state, destination_state):
     log.info(f"Pushing commit {commit} for {filename}")
     origin = repo.remote(name='origin')
     origin.push()
+    log.info(f"Successfully moved {filename}")
   except Exception as e:
     log.error(f"Failed to move {filename}")
     log.error(e)
-  log.info(f"Successfully moved {filename}")
 
 # Lists all jobs (i.e. yaml files) within a given state
 def list_job_files(state):

--- a/goji/jobs.py
+++ b/goji/jobs.py
@@ -12,7 +12,9 @@ def job_states():
 # Returns whether or the job was applied successfuly
 def apply_job(job_name):
   try:
-    k8s_config = config.load_kube_config()
+    print("Applying job {job_name}")
+    #k8s_config = config.load_kube_config()
+    k8s_config = config.load_incluster_config()
     k8s_client = client.api_client.ApiClient(configuration=k8s_config)
     create_from_yaml(k8s_client, f"jobs/queued/{job_name}")
   except Exception as e:

--- a/goji/logger.py
+++ b/goji/logger.py
@@ -1,0 +1,11 @@
+import logging
+import sys
+
+log = logging.getLogger()
+log.setLevel(logging.DEBUG)
+
+handler = logging.StreamHandler(sys.stdout)
+handler.setLevel(logging.INFO)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+handler.setFormatter(formatter)
+log.addHandler(handler)

--- a/goji/server.py
+++ b/goji/server.py
@@ -1,0 +1,7 @@
+from flask import Flask
+
+app = Flask(__name__)
+
+@app.route('/')
+def hello_world():
+    return 'Hello, World!'

--- a/goji/server.py
+++ b/goji/server.py
@@ -1,7 +1,59 @@
+import os, threading, queue
+
+import git
+
 from flask import Flask
+from flask import request
+
+from goji.commands import process
+from goji.jobs import list_job_files
+
 
 app = Flask(__name__)
 
 @app.route('/health')
-def hello_world():
+def health():
+    return 'OK!'
+
+q = queue.Queue()
+
+def worker():
+  while True:
+    item = q.get()
+    repository = os.environ['GIT_REPOSITORY']
+    repo = None
+
+    if os.path.exists('jobs'):
+      repo = git.Repo('jobs')
+      repo.remotes.origin.pull()
+    elif repository:
+      os.makedirs("jobs")
+      print("Cloning " + repository)
+      repo = git.Repo.clone_from(repository, "jobs")
+      print("Done")
+
+    print("Fetching latest repository")
+    jobs = list_job_files("queued")
+    print("Processing jobs")
+    process.command_process(jobs)
+    print(jobs)
+
+
+    q.task_done()
+
+threading.Thread(target=worker, daemon=True).start()
+
+@app.route('/webhooks/github', methods=["POST"])
+def github_webhook():
+  payload = request.get_json()
+
+  print("Payload:")
+  print(payload)
+
+  # TODO: Check secret and target repository matches expected repository
+  if "before" in payload or "after" in payload:
+    # Trigger a process event
+    q.put("Event")
+    return 'Toot!'
+  else:
     return 'OK!'

--- a/goji/server.py
+++ b/goji/server.py
@@ -5,6 +5,7 @@ import git
 from flask import Flask
 from flask import request
 
+from goji.logger import log
 from goji.commands import process
 from goji.jobs import list_job_files
 
@@ -24,15 +25,15 @@ def worker():
     repo = None
 
     if os.path.exists('jobs'):
-      print("Pulling latest changes")
+      log.info("Pulling latest changes")
       repo = git.Repo('jobs')
       repo.remotes.origin.pull()
     elif repository:
-      print("Cloning jobs directory from {repository}")
+      log.info("Cloning jobs directory from {repository}")
       os.makedirs("jobs")
-      print("Cloning " + repository)
+      log.info("Cloning " + repository)
       repo = git.Repo.clone_from(repository, "jobs")
-      print("Done")
+      log.info("Done")
 
     jobs = list_job_files("queued")
     process.command_process(jobs)
@@ -47,9 +48,9 @@ def github_webhook():
 
   # TODO: Check secret and target repository matches expected repository
   if "before" in payload or "after" in payload:
-    print("Received webhook, checking for new queued jobs")
+    log.info("Received webhook, checking for new queued jobs")
     q.put("webhook event")
     return 'OK!'
   else:
-    print("Received webhook, but not interested")
+    log.info("Received webhook, but not interested")
     return 'OK!'

--- a/goji/server.py
+++ b/goji/server.py
@@ -2,6 +2,6 @@ from flask import Flask
 
 app = Flask(__name__)
 
-@app.route('/')
+@app.route('/health')
 def hello_world():
-    return 'Hello, World!'
+    return 'OK!'

--- a/goji/server.py
+++ b/goji/server.py
@@ -24,20 +24,18 @@ def worker():
     repo = None
 
     if os.path.exists('jobs'):
+      print("Pulling latest changes")
       repo = git.Repo('jobs')
       repo.remotes.origin.pull()
     elif repository:
+      print("Cloning jobs directory from {repository}")
       os.makedirs("jobs")
       print("Cloning " + repository)
       repo = git.Repo.clone_from(repository, "jobs")
       print("Done")
 
-    print("Fetching latest repository")
     jobs = list_job_files("queued")
-    print("Processing jobs")
     process.command_process(jobs)
-    print(jobs)
-
 
     q.task_done()
 
@@ -47,13 +45,11 @@ threading.Thread(target=worker, daemon=True).start()
 def github_webhook():
   payload = request.get_json()
 
-  print("Payload:")
-  print(payload)
-
   # TODO: Check secret and target repository matches expected repository
   if "before" in payload or "after" in payload:
-    # Trigger a process event
-    q.put("Event")
-    return 'Toot!'
+    print("Received webhook, checking for new queued jobs")
+    q.put("webhook event")
+    return 'OK!'
   else:
+    print("Received webhook, but not interested")
     return 'OK!'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,19 @@
 cachetools==3.1.1
 certifi==2019.11.28
 chardet==3.0.4
+click==7.1.2
+Flask==1.1.2
+gevent==20.5.0
 gitdb2==2.0.6
 GitPython==3.0.5
+goji==0.0.1
 google-auth==1.7.1
+greenlet==0.4.15
 idna==2.8
+itsdangerous==1.1.0
+Jinja2==2.11.2
 kubernetes==10.0.1
+MarkupSafe==1.1.1
 oauthlib==3.1.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.7
@@ -18,3 +26,4 @@ six==1.13.0
 smmap2==2.0.5
 urllib3==1.25.7
 websocket-client==0.56.0
+Werkzeug==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ Flask==1.1.2
 gevent==20.5.0
 gitdb2==2.0.6
 GitPython==3.0.5
-goji==0.0.1
 google-auth==1.7.1
 greenlet==0.4.15
 idna==2.8


### PR DESCRIPTION
Added a server mode for running inside Kubernetes

- Added a new command `goji server`
- Added a Dockerfile to build the container image
- Added a chart for installation to Kubernetes
- Added a logger for Gevent, and used in place of basic print outputt

The helm chart defines:

- A single instance deployment
- A default serviceaccount/clusterrole and binding with access to create batch jobs

Environment configuration:

- GIT_USERNAME - The username to check code out with
- GIT_PASSWORD - A password (or PAT)
- GIT_REPOSITORY - The jobs repository to clone
- GITHUB_WEBHOOK_SECRET - The secret defined in the github webhook configuration
