### PR TITLE
Take image tag from chart appVersion

### DIFF
--- a/charts/goji/templates/deployment.yaml
+++ b/charts/goji/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: GIT_USERNAME

--- a/charts/goji/values.yaml
+++ b/charts/goji/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 
 image:
   repository: shteou/goji
-  tag: latest
+  tag: ""
   pullPolicy: Always
 
 imagePullSecrets: []


### PR DESCRIPTION
Updated the deployment image to align with the chart's appVersion
unless explicitly overidden