### PR TITLE
Add unit tests for command_process

### DIFF
--- a/goji/commands/process.py
+++ b/goji/commands/process.py
@@ -1,20 +1,20 @@
 import logging, sys
 
 from goji.logger import log
-from goji.jobs import *
+from goji.jobs import apply_job, delete_jobs, duplicate_jobs, move_job 
 
-def removeDuplicates(jobs):
+def remove_duplicates(jobs):
   log.info("Checking for duplicate jobs")
   duplicates = duplicate_jobs()
 
   if len(duplicates) > 0 :
-    log.warn(f"Removing duplicate jobs: {duplicates}")
+    log.warning(f"Removing duplicate jobs: {duplicates}")
     delete_jobs("queued", duplicates, "Deleting duplicated jobs")
 
   return [j for j in jobs if j not in duplicates]
 
 
-def apply_job(job):
+def process_job(job):
   try:
     log.info(f"Applying queued job: {job}")
     
@@ -29,10 +29,10 @@ def apply_job(job):
 # Applies all queued jobs and transitions to processing/failed
 # as required
 def command_process(jobs):
-  unique_jobs = removeDuplicates(jobs)
+  unique_jobs = remove_duplicates(jobs)
 
   log.info(f"Applying remaining queued jobs: {unique_jobs}")
   for job in unique_jobs:
-    apply_job(job)
+    process_job(job)
 
   log.info("Finished applying queued jobs")

--- a/goji/jobs.py
+++ b/goji/jobs.py
@@ -31,8 +31,8 @@ def apply_job(job_name):
 # Move a job from one state to another, creating a commit and pushing the result
 def move_job(filename, source_state, destination_state):
   log.info(f"Moving {filename} from {source_state} to {destination_state}")
-  repo = git.Repo("jobs")
   try:
+    repo = git.Repo("jobs")
     repo.index.move([os.path.join(source_state, filename), os.path.join(destination_state, filename)])
     log.info(f"Committing state transition for {filename}")
     commit = repo.index.commit(f"{filename} transitioned from {source_state} to {destination_state}")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+import logging
+
+logging.disable(logging.CRITICAL)

--- a/tests/test_command_process.py
+++ b/tests/test_command_process.py
@@ -1,0 +1,58 @@
+import unittest
+
+from unittest import mock
+from mock import patch
+
+from goji.commands.process import command_process 
+
+class CommandProcessTestCase(unittest.TestCase):
+  @patch('goji.commands.process.duplicate_jobs')
+  def test_command_proccess_empty_jobs(self, duplicate_jobs):
+    duplicate_jobs.return_value = []
+
+    command_process([])
+
+    duplicate_jobs.assert_called()
+
+
+  @patch('goji.commands.process.move_job')
+  @patch('goji.commands.process.duplicate_jobs')
+  @patch('goji.commands.process.delete_jobs')
+  @patch('goji.commands.process.apply_job')
+  def test_command_proccess_duplicate_jobs(self, apply_job, delete_jobs, duplicate_jobs, move_job):
+    duplicate_jobs.return_value = ["foo"]
+
+    command_process(["foo"])
+
+    delete_jobs.assert_called_with("queued", ["foo"], "Deleting duplicated jobs")
+    apply_job.assert_not_called()
+    duplicate_jobs.assert_called()
+    move_job.assert_not_called()
+
+  @patch('goji.commands.process.move_job')
+  @patch('goji.commands.process.duplicate_jobs')
+  @patch('goji.commands.process.apply_job')
+  def test_command_process_successful_job(self, apply_job, duplicate_jobs, move_job):
+    duplicate_jobs.return_value = []
+    apply_job.return_value = True
+
+    command_process(["foo"])
+
+    apply_job.assert_called_with("foo")
+    duplicate_jobs.assert_called()
+    move_job.assert_called_with("foo", "queued", "processing")
+
+
+  @patch('goji.commands.process.move_job')
+  @patch('goji.commands.process.duplicate_jobs')
+  @patch('goji.commands.process.apply_job')
+  def test_command_process_failed_job(self, apply_job, duplicate_jobs, move_job):
+    duplicate_jobs.return_value = []
+    apply_job.return_value = False
+
+    command_process(["foo"])
+
+    apply_job.assert_called_with("foo")
+    duplicate_jobs.assert_called()
+    move_job.assert_called_with("foo", "queued", "failed")
+


### PR DESCRIPTION
- Fixed use of deprecated warn method
- Fixed recursion bug in commands.process.apply_job (renamed to
  process_job)