### PR TITLE
Rename github actions

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
 
-  build:
+  build-docker:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -10,7 +10,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  build-python:
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Renamed github actions to allow them to both be required for PRs
to be merged

Fixes #42